### PR TITLE
Ruby 2.4 미만 버전 설치시 openssl 의존성 문제 관련 포스팅 

### DIFF
--- a/_posts/2019-11-12-ruby-2-4-openssl-dependency.md
+++ b/_posts/2019-11-12-ruby-2-4-openssl-dependency.md
@@ -25,3 +25,6 @@ RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl" rbenv install 2.
 # For RVM
 RUBY_CONFIGURE_OPTS="--with-openssl-dir=/usr/local/opt/openssl" rvm install 2.3.3
 ```
+
+* 출처
+    * <a href="https://github.com/rbenv/ruby-build/issues/1353" target="_blank" rel="noopener">Cannot install Ruby versions < 2.4 because of openssl@1.1 dependency</a>


### PR DESCRIPTION

내용 및 출처 추가하여 포스팅 