### PR TITLE
URL 링크에 .html 가 붙지 않도록 하다

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ url: "https://blog.dizy.dev" # the base hostname & protocol for your site
 twitter_username: dizy64
 github_username:  dizy64
 facebook_username: dizy64
+permalink: pretty
 
 # Build settings
 markdown: kramdown


### PR DESCRIPTION
기존에 이미 공유한 링크들이 문제가 될 수 있지만
이후의 글을 pretty url 로 공유 할 수 있도록 하기 위해 수정